### PR TITLE
Fjerne infoboks og lenke til bekreftelse artikkel

### DIFF
--- a/src/components/bekreftelse/ingen-tilgjengelige-bekreftelser.tsx
+++ b/src/components/bekreftelse/ingen-tilgjengelige-bekreftelser.tsx
@@ -7,13 +7,13 @@ interface Props {
 }
 const TEKSTER = {
     nb: {
-        melding: 'Det er ingen tilgjengelige bekreftelser å sende inn',
+        melding: 'Du har ingen bekreftelser å sende inn',
     },
     nn: {
-        melding: 'Det er ingen tilgjengelege stadfestingar å senda inn',
+        melding: 'Du har ingen stadfestingar å senda inn',
     },
     en: {
-        melding: 'No confirmation forms available at the moment'
+        melding: 'You have no confirmation forms to submit'
     }
 };
 

--- a/src/components/bekreftelse/ingen-tilgjengelige-bekreftelser.tsx
+++ b/src/components/bekreftelse/ingen-tilgjengelige-bekreftelser.tsx
@@ -1,4 +1,5 @@
 import { lagHentTekstForSprak, Sprak } from '@navikt/arbeidssokerregisteret-utils';
+import LenkeTilBekreftelseArtikkel from '../lenke-til-bekreftelse-artikkel';
 import { Alert } from '@navikt/ds-react';
 
 interface Props {
@@ -18,5 +19,12 @@ const TEKSTER = {
 
 export default function IngenTilgjengeligeBekreftelser(props: Props) {
     const tekst = lagHentTekstForSprak(TEKSTER, props.sprak);
-    return <Alert variant={'info'}>{tekst('melding')}</Alert>;
+    return (
+            <>
+                <Alert variant={'info'}>
+                    {tekst('melding')}
+                </Alert>
+                <LenkeTilBekreftelseArtikkel sprak={props.sprak}/>
+            </>
+        );
 }

--- a/src/components/bekreftelse/tilgjengelig-bekreftelse-link.tsx
+++ b/src/components/bekreftelse/tilgjengelig-bekreftelse-link.tsx
@@ -7,6 +7,7 @@ import { lagHentTekstForSprak, Sprak } from '@navikt/arbeidssokerregisteret-util
 import { loggAktivitet } from '@/lib/amplitude';
 import tilSprakAvhengigAppPath from '@/lib/sprak-avhengig-url';
 import { ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons';
+import LenkeTilBekreftelseArtikkel from '../lenke-til-bekreftelse-artikkel';
 import styles from './tilgjengelig-bekreftelse-link.module.css';
 
 interface Props {
@@ -45,21 +46,24 @@ const TilgjengeligBekreftelseLink = (props: Props) => {
     const tekst = lagHentTekstForSprak(TEKSTER, sprak);
 
     return (
+        <>
         <LinkPanel
             className={styles.tilgjengeligBekreftelseLink}
             style={{ background: 'var(--a-surface-warning-subtle)' }}
             href={tilSprakAvhengigAppPath('/bekreftelse', sprak)}
             onClick={onClick}
             as={NextLink}
-        >
+            >
             <LinkPanel.Title className={'flex items-center'}>
                 <ExclamationmarkTriangleFillIcon
                     title={tekst('iconTitle')}
                     className={`mr-4 ${styles.ikon}`}
                     style={{ color: 'var(--a-icon-warning)'}}
-                />
+                    />
                 {tekst('title')}</LinkPanel.Title>
         </LinkPanel>
+        <LenkeTilBekreftelseArtikkel sprak={sprak} />
+        </>
     );
 };
 

--- a/src/components/lenke-til-bekreftelse-artikkel.tsx
+++ b/src/components/lenke-til-bekreftelse-artikkel.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Box, Link } from '@navikt/ds-react';
+import { lagHentTekstForSprak, Sprak } from '@navikt/arbeidssokerregisteret-utils';
+import { loggAktivitet } from '@/lib/amplitude';
+
+const TEKSTER = {
+    nb: {
+       linkText: 'Les mer om å bekrefte at du vil være arbeidssøker',
+    },
+    nn: {
+        linkText: 'Les meir om å stadfesta at du vil vera arbeidssøkjar',
+    },
+    en: {
+        linkText: 'Read more about confirming that you will be a jobseeker',
+    },
+};
+
+interface Props {
+    sprak: Sprak;
+}
+const getUrl = (sprak: Sprak) => {
+    if (sprak === 'en') {
+        return 'https://www.nav.no/confirm-jobseeker/en';
+    } else if (sprak === 'nn') {
+        return 'https://www.nav.no/bekreft-arbeidssoker/nn';
+    } else {
+        return 'https://www.nav.no/bekreft-arbeidssoker';
+    }
+};
+
+const LenkeTilBekreftelseArtikkel = (props: Props) => {
+    const { sprak } = props;
+    const tekst = lagHentTekstForSprak(TEKSTER, sprak);
+
+    const onClick = () => {
+        loggAktivitet({
+            aktivitet:
+                'Trykker på "Les mer om å bekrefte at du vil være arbeidssøker"',
+        });
+    };
+
+    return (
+        <Box className={'mb-2 mt-2'}>
+          <Link href={getUrl(sprak)} onClick={onClick}>
+              {tekst('linkText')}
+          </Link>
+        </Box>
+    );
+};
+
+export default LenkeTilBekreftelseArtikkel;

--- a/src/lib/amplitude.ts
+++ b/src/lib/amplitude.ts
@@ -64,6 +64,7 @@ type AktivitetData =
     | { aktivitet: 'Går til siden for historikk' }
     | { aktivitet: 'Trykker på "Gå til Bekreftelse" fra forsiden' }
     | { aktivitet: 'Trykker på "Les mer om å bekrefte at du vil være arbeidssøker" på nav.no fra varsel på forsiden' }
+    | { aktivitet: 'Trykker på "Les mer om å bekrefte at du vil være arbeidssøker"' }
     | { aktivitet: 'Trykker på "Kontakt oss" fra avbryt bekreftelse' };
 
 


### PR DESCRIPTION
Fjerner infoboksen som ble brukt i forkant av lansering av bekreftelse av arbeidssøkerperioder