### PR TITLE
Flytte kall mot aggregerte perioder til oppslag api v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6383,10 +6383,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -17321,6 +17324,15 @@
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.0.tgz",
       "integrity": "sha512-sDaprBAfzCQiOgo2pO+LhnV0Wt2wBgartjrr+dpcTORYVnnXD0gwhHhiiyIih9hQbq+JnbqH4odgcFWhqCGidw==",
       "license": "MIT"
+    },
+    "node_modules/next/node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -43,10 +43,11 @@ async function fetchAggregertePerioder(props: AggregertePerioderProps): Promise<
         });
     }
     const { visKunSisteInformasjon } = props;
-    const AGGREGERTE_PERIODER_URL = `${process.env.ARBEIDSSOEKERREGISTERET_OPPSLAG_API_URL}/api/v1/arbeidssoekerperioder-aggregert${visKunSisteInformasjon ? '?siste=true' : ''}`;
+    const AGGREGERTE_PERIODER_URL = `${process.env.OPPSLAG_API_V2_URL}/api/v1/arbeidssoekerperioder-aggregert${visKunSisteInformasjon ? '?siste=true' : ''}`;
+    const audience = `${process.env.NAIS_CLUSTER_NAME}:paw:paw-arbeidssoekerregisteret-api-oppslag-v2`;
     try {
         const reqHeaders = await headers();
-        const tokenXToken = await getTokenXToken(stripBearer(reqHeaders.get('authorization')!));
+        const tokenXToken = await getTokenXToken(stripBearer(reqHeaders.get('authorization')!), audience);
         const traceId = uuidv4();
         logger.info({ x_trace_id: traceId }, `Starter GET ${AGGREGERTE_PERIODER_URL}`);
 


### PR DESCRIPTION
Lar endepunktet mot aggregert perioder gå til oppslag api v2 i stedet for oppslag api.

Dette er en mellomløsning for å gå over til oppslag v2 hvor vi på sikt vil gå over fra aggregerte perioder til tidslinjer.