### PR TITLE
Potential fix for code scanning alert no. 3: Server-side request forgery

### DIFF
--- a/src/app/api/brukerprofil/tjenestestatus/route.ts
+++ b/src/app/api/brukerprofil/tjenestestatus/route.ts
@@ -1,5 +1,4 @@
-import { gyldigTjenestestatus } from '@/lib/gyldig-tjenestestatus';
-import { TjenestestatusRequest } from '@/model/brukerprofil';
+import { TJENESTESTATUSER, TjenestestatusRequest } from '@/model/brukerprofil';
 import { logger } from '@navikt/next-logger';
 import { headers } from 'next/headers';
 import { v4 as uuidv4 } from 'uuid';
@@ -8,7 +7,7 @@ import { getToken, requestOboToken } from '@navikt/oasis';
 const brukerMock = process.env.ENABLE_MOCK === 'enabled';
 const BRUKERPROFIL_CLIENT_ID = `${process.env.NAIS_CLUSTER_NAME}:paw:paw-arbeidssoekerregisteret-api-mine-stillinger`;
 const TJENESTESTATUS_API_URL = `${process.env.BRUKERPROFIL_API_URL}/api/v1/brukerprofil/tjenestestatus`;
-const ALLOWED_TJENESTESTATUSER = new Set(['AKTIV', 'INAKTIV']);
+const ALLOWED_TJENESTESTATUSER = new Set(TJENESTESTATUSER);
 
 /**
  * PUT endepunktet for `tjenestestatus` i brukerprofil API.
@@ -52,19 +51,6 @@ export const PUT = async (request: Request) => {
                 status: 400,
                 headers: { 'Content-Type': 'application/json' },
             });
-        }
-
-        if (!gyldigTjenestestatus(body)) {
-            logger.error({ x_trace_id: traceId }, 'Ugyldig request format');
-            return new Response(
-                JSON.stringify({
-                    error: 'Ugyldig request format',
-                }),
-                {
-                    status: 400,
-                    headers: { 'Content-Type': 'application/json' },
-                },
-            );
         }
 
         const { tjenestestatus } = body;

--- a/src/app/api/brukerprofil/tjenestestatus/route.ts
+++ b/src/app/api/brukerprofil/tjenestestatus/route.ts
@@ -8,6 +8,7 @@ import { getToken, requestOboToken } from '@navikt/oasis';
 const brukerMock = process.env.ENABLE_MOCK === 'enabled';
 const BRUKERPROFIL_CLIENT_ID = `${process.env.NAIS_CLUSTER_NAME}:paw:paw-arbeidssoekerregisteret-api-mine-stillinger`;
 const TJENESTESTATUS_API_URL = `${process.env.BRUKERPROFIL_API_URL}/api/v1/brukerprofil/tjenestestatus`;
+const ALLOWED_TJENESTESTATUSER = new Set(['AKTIV', 'INAKTIV']);
 
 /**
  * PUT endepunktet for `tjenestestatus` i brukerprofil API.
@@ -68,7 +69,15 @@ export const PUT = async (request: Request) => {
 
         const { tjenestestatus } = body;
 
-        const urlWithPath = `${TJENESTESTATUS_API_URL}/${tjenestestatus}`;
+        if (!ALLOWED_TJENESTESTATUSER.has(tjenestestatus)) {
+            logger.error({ x_trace_id: traceId }, 'Ugyldig tjenestestatus');
+            return new Response(JSON.stringify({ error: 'Ugyldig tjenestestatus' }), {
+                status: 400,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
+
+        const urlWithPath = `${TJENESTESTATUS_API_URL}/${encodeURIComponent(tjenestestatus)}`;
         logger.info({ x_trace_id: traceId }, `Starter PUT ${urlWithPath}`);
 
         const response = await fetch(urlWithPath, {

--- a/src/lib/gyldig-tjenestestatus.test.ts
+++ b/src/lib/gyldig-tjenestestatus.test.ts
@@ -2,46 +2,22 @@ import { describe, expect, it } from 'vitest';
 import { gyldigTjenestestatus } from './gyldig-tjenestestatus';
 
 describe('validere typesjekken til gyldigTjenestestatus', () => {
-    it('Skal returnere true for gyldig TjenestestatusRequest', () => {
-        const validRequest = { tjenestestatus: 'aktiv' };
-        expect(gyldigTjenestestatus(validRequest)).toBe(true);
+    it('Skal returnere true for alle gyldige tjenestestatuser', () => {
+        expect(gyldigTjenestestatus({ tjenestestatus: 'AKTIV' })).toBe(true);
+        expect(gyldigTjenestestatus({ tjenestestatus: 'INAKTIV' })).toBe(true);
+        expect(gyldigTjenestestatus({ tjenestestatus: 'OPT_OUT' })).toBe(true);
+        expect(gyldigTjenestestatus({ tjenestestatus: 'KAN_IKKE_LEVERES' })).toBe(true);
     });
 
-    it('Skal returnere false for null', () => {
-        expect(gyldigTjenestestatus(null as any)).toBe(false);
-    });
-
-    it('Skal returnere false for undefined', () => {
-        expect(gyldigTjenestestatus(undefined as any)).toBe(false);
-    });
-
-    it('Skal returnere false for non-object typer', () => {
-        expect(gyldigTjenestestatus('string' as any)).toBe(false);
-        expect(gyldigTjenestestatus(123 as any)).toBe(false);
-        expect(gyldigTjenestestatus(true as any)).toBe(false);
-        expect(gyldigTjenestestatus([] as any)).toBe(false);
-    });
-
-    it('Skal returnere false for objekter uten tjenestestatus', () => {
-        expect(gyldigTjenestestatus({} as any)).toBe(false);
-        expect(gyldigTjenestestatus({ other: 'value' } as any)).toBe(false);
-    });
-
-    it('Skal returnere false for objekter med tjenestestatus med feil type', () => {
-        expect(gyldigTjenestestatus({ tjenestestatus: 123 } as any)).toBe(false);
-        expect(gyldigTjenestestatus({ tjenestestatus: null } as any)).toBe(false);
-        expect(gyldigTjenestestatus({ tjenestestatus: undefined } as any)).toBe(false);
-        expect(gyldigTjenestestatus({ tjenestestatus: {} } as any)).toBe(false);
-    });
-
-    it('Skal returnere false for objekter med tjenestestatus med whitespace-only og tomme strenger ', () => {
+    it('Skal returnere false for ugyldig tjenestestatus', () => {
+        expect(gyldigTjenestestatus({ tjenestestatus: 'aktiv' })).toBe(false);
+        expect(gyldigTjenestestatus({ tjenestestatus: 'UKJENT' })).toBe(false);
         expect(gyldigTjenestestatus({ tjenestestatus: '' })).toBe(false);
-        expect(gyldigTjenestestatus({ tjenestestatus: '   ' })).toBe(false);
-        expect(gyldigTjenestestatus({ tjenestestatus: '\t\n' })).toBe(false);
     });
 
-    it('Skal returnere true når man sender gyldig type med ekstra whitespace', () => {
-        expect(gyldigTjenestestatus({ tjenestestatus: ' aktiv ' })).toBe(true);
-        expect(gyldigTjenestestatus({ tjenestestatus: '\taktiv\n' })).toBe(true);
+    it('Skal returnere false for manglende eller null body', () => {
+        expect(gyldigTjenestestatus(null as any)).toBe(false);
+        expect(gyldigTjenestestatus(undefined as any)).toBe(false);
+        expect(gyldigTjenestestatus({} as any)).toBe(false);
     });
 });

--- a/src/lib/gyldig-tjenestestatus.ts
+++ b/src/lib/gyldig-tjenestestatus.ts
@@ -1,4 +1,6 @@
-import { TjenestestatusRequest } from '@/model/brukerprofil';
+import { TJENESTESTATUSER, TjenestestatusRequest } from '@/model/brukerprofil';
+
+const ALLOWED_TJENESTESTATUSER = new Set(TJENESTESTATUSER);
 
 /**
  * Manuell sjekk av type for TjenestestatusRequest.
@@ -9,10 +11,5 @@ import { TjenestestatusRequest } from '@/model/brukerprofil';
  * @returns True dersom body inneholder gyldig tjenestestatus
  */
 export function gyldigTjenestestatus(body: any): body is TjenestestatusRequest {
-    return (
-        typeof body === 'object' &&
-        body !== null &&
-        typeof body.tjenestestatus === 'string' &&
-        body.tjenestestatus.trim().length > 0
-    );
+    return ALLOWED_TJENESTESTATUSER.has(body?.tjenestestatus);
 }

--- a/src/model/brukerprofil.ts
+++ b/src/model/brukerprofil.ts
@@ -3,7 +3,8 @@
  * Les mer her: https://heyapi.dev/openapi-ts/get-started
  * OpenApi-Spec: https://raw.githubusercontent.com/navikt/paw-arbeidssoekerregisteret-monorepo-ekstern/refs/heads/main/apps/mine-stillinger-api/src/main/resources/openapi/openapi-spec.yaml
  */
-export type Tjenestestatus = 'AKTIV' | 'INAKTIV' | 'OPT_OUT' | 'KAN_IKKE_LEVERES';
+export const TJENESTESTATUSER = ['AKTIV', 'INAKTIV', 'OPT_OUT', 'KAN_IKKE_LEVERES'] as const;
+export type Tjenestestatus = (typeof TJENESTESTATUSER)[number];
 
 export type Brukerprofil = {
     identitetsnummer: string;


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/paw-arbeidssoekerregisteret-for-personbruker/security/code-scanning/3](https://github.com/navikt/paw-arbeidssoekerregisteret-for-personbruker/security/code-scanning/3)

Use a strict server-controlled allow-list for `tjenestestatus` in this route before constructing `urlWithPath`. Keep existing behavior, but add a defensive check that only permits known literal values and rejects anything else with 400. Then build URL from the validated value (optionally encoded) so outgoing request path cannot be attacker-shaped.

In `src/app/api/brukerprofil/tjenestestatus/route.ts`:
- Add a constant allow-list near top-level constants.
- After extracting `tjenestestatus` (around line 69), verify it is in allow-list.
- Return `400` with JSON error if invalid.
- Build `urlWithPath` from the validated value (using `encodeURIComponent` for defense-in-depth).

No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
