### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ jobs:
     test:
         name: Run tests
         runs-on: ubuntu-latest
+        permissions:
+            contents: 'read'
         steps:
             - name: Checkout code
               uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/paw-arbeidssoekerregisteret-for-personbruker/security/code-scanning/1](https://github.com/navikt/paw-arbeidssoekerregisteret-for-personbruker/security/code-scanning/1)

Add an explicit `permissions` block to the `test` job in `.github/workflows/deploy.yml` to restrict `GITHUB_TOKEN` to least privilege.

Best single fix without changing functionality:
- In `.github/workflows/deploy.yml`, under `jobs.test` (right after `runs-on`), add:
  - `permissions:`
  - `contents: 'read'`

Why this is best here:
- It addresses the exact flagged job.
- It keeps existing behavior unchanged while documenting required access.
- It avoids unintentionally changing permissions for other jobs by adding a workflow-wide default that might conflict with jobs needing broader scopes.

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
